### PR TITLE
     modified:pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.1</version>
+            <version>3.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.oltu.oauth2</groupId>


### PR DESCRIPTION
    <groupId>com.squareup.okhttp3</groupId>
            <artifactId>okhttp</artifactId>
	    a<version>3.14.2</version>

if the version of okhttp is 4.9.1, it will  possibly not be able to import into the Maven project,
my version of maven is  3.5.2, in this version , the import okhttp will fail;
so if using the version 3.14.2,it  will be better.
