### PR TITLE
fix: fix CasdoorUser array serializable error

### DIFF
--- a/src/main/java/org/casbin/casdoor/entity/CasdoorUser.java
+++ b/src/main/java/org/casbin/casdoor/entity/CasdoorUser.java
@@ -17,6 +17,7 @@ package org.casbin.casdoor.entity;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -80,8 +81,8 @@ public class CasdoorUser implements Serializable {
     private String gitlab;
     private String ldap;
     private Map<String, String> properties;
-    private CasdoorRole[] roles;
-    private CasdoorPermission[] permissions;
+    private List<CasdoorRole> roles;
+    private List<CasdoorPermission> permissions;
 
     @JsonGetter("isOnline")
     public boolean isOnline() {


### PR DESCRIPTION
In order to solve the problem that the tokens reflected by some users do not contain roles and permissions information，[casdoor#1060](https://github.com/casdoor/casdoor/pull/1060) to solve.
![image](https://user-images.githubusercontent.com/56248584/186115115-da53bb1a-75e8-488b-b9e6-d2258301663c.png)
After the test, using the object array type, the BeanUtils.copyProperties() method will have problems. It is successfully changed to list.