### PR TITLE
fix: fix CasdoorUser serializable method to ObjectMapper & the entity annotation lose

### DIFF
--- a/src/main/java/org/casbin/casdoor/entity/CasdoorPermission.java
+++ b/src/main/java/org/casbin/casdoor/entity/CasdoorPermission.java
@@ -14,6 +14,7 @@
 
 package org.casbin.casdoor.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -38,5 +39,6 @@ public class CasdoorPermission implements Serializable {
     private String[] resources;
     private String[] actions;
     private String effect;
+    @JsonProperty("isEnabled")
     private boolean isEnabled;
 }

--- a/src/main/java/org/casbin/casdoor/entity/CasdoorRole.java
+++ b/src/main/java/org/casbin/casdoor/entity/CasdoorRole.java
@@ -14,6 +14,7 @@
 
 package org.casbin.casdoor.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,5 +34,6 @@ public class CasdoorRole implements Serializable {
     private String displayName;
     private String[] users;
     private String[] roles;
+    @JsonProperty("isEnabled")
     private boolean isEnabled;
 }


### PR DESCRIPTION
The original BeanUtils.copyProperties copy method cannot deep copy arrays and lists
Now I replace it with using ObjectMapper to deserialize via json payloader