### PR TITLE
feat: add missing Sign Up and Sign In items fields in Application

### DIFF
--- a/src/main/java/org/casbin/casdoor/entity/Application.java
+++ b/src/main/java/org/casbin/casdoor/entity/Application.java
@@ -57,6 +57,9 @@ public class Application implements Serializable {
     public int formOffset;
     public String formSideHtml;
     public String formBackgroundUrl;
+    public List<SigninMethod> signinMethods;
+    public List<SigninItem> signinItems;
+    public List<SignupItem> signupItems;
 
     public Application() {
     }
@@ -70,5 +73,33 @@ public class Application implements Serializable {
         this.homepageUrl = homepageUrl;
         this.description = description;
         this.organization = organization;
+    }
+
+    public static class SigninMethod {
+        public String name;
+        public String displayName;
+        public String rule;
+    }
+
+    public static class SigninItem {
+
+        public String name;
+        public boolean visible;
+        public String label;
+        public String placeholder;
+        public String rule;
+        public boolean isCustom;
+    }
+
+    public static class SignupItem {
+
+        public String label;
+        public String name;
+        public String placeholder;
+        public boolean prompted;
+        public String regex;
+        public boolean required;
+        public String rule;
+        public boolean visible;
     }
 }

--- a/src/main/java/org/casbin/casdoor/entity/Application.java
+++ b/src/main/java/org/casbin/casdoor/entity/Application.java
@@ -82,7 +82,6 @@ public class Application implements Serializable {
     }
 
     public static class SigninItem {
-
         public String name;
         public boolean visible;
         public String label;
@@ -92,7 +91,6 @@ public class Application implements Serializable {
     }
 
     public static class SignupItem {
-
         public String label;
         public String name;
         public String placeholder;


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-java-sdk/issues/86

The Application entity found at org.casbin.casdoor.entity.Application is missing required fields that are needed to correctly load the OAuth2 page and admin dashboard.

Fields missing are:

- Sign Up Items
- Sign In Items
- Sign In Methods

Due to these missing fields the database is holding null. This results with a front-end error as the UI is expecting an array (even if it's an empty array) in comparison to null for both the OAuth2 login page, and the Admin Dashboard.