### PR TITLE
fix(plan): add missing paymentProviders field and update options data…

### DIFF
--- a/src/main/java/org/casbin/casdoor/entity/Plan.java
+++ b/src/main/java/org/casbin/casdoor/entity/Plan.java
@@ -27,7 +27,8 @@ public class Plan {
     public String currency;
     public boolean isEnabled;
     public String role;
-    public List<String> options;
+    public String [] paymentProviders;
+    public String [] options;
 
     public Plan(String owner, String name, String createdTime, String displayName, String description) {
         this.owner = owner;


### PR DESCRIPTION
… type

### Description
This PR addresses the following issues in the `Plan` entity of the Java Casdoor SDK:

- Added: The missing `paymentProviders` field, which is required to match the Golang implementation. This field is defined as a `String[]` in the Golang code.
- Updated: The data type of the `options` field to `String[]`, ensuring compatibility with the expected data types in the Golang codebase.

### Changes Made
- Introduced a new field `public String[] paymentProviders;` in the `Plan` class.
- Changed the data type of the `options` field to `public String[] options;.

### Related Issue
This PR addresses the mismatch between the Java and Golang implementations regarding the `Plan` entity.

Please review the changes and let me know if there are any suggestions or concerns.