### PR TITLE
Update description field in Plan entity to accept a list of strings

### DIFF
--- a/src/main/java/org/casbin/casdoor/entity/Plan.java
+++ b/src/main/java/org/casbin/casdoor/entity/Plan.java
@@ -21,7 +21,7 @@ public class Plan {
     public String name;
     public String createdTime;
     public String displayName;
-    public String description;
+    public List<String> description;
 
     public double price;
     public String currency;


### PR DESCRIPTION
This pull request updates the description field in the Plan entity to accept a list of strings instead of a single string with a 100-character limit. This change will allow for more detailed and structured descriptions for each plan enhancing clarity and flexibility.